### PR TITLE
Remove PHP 7 scalar types to make module compatible with PHP >=5.3.0

### DIFF
--- a/code/BetterDatetimeField.php
+++ b/code/BetterDatetimeField.php
@@ -112,7 +112,7 @@ class BetterDatetimeField extends FormField
                 $day = !empty($value['Day']) ? $value['Day'] : null;
                 $month = !empty($value['Month']) ? $value['Month'] : null;
                 $year = !empty($value['Year']) ? $value['Year'] : null;
-                
+
                 if ($this->Required() && (empty($day) || empty($month) || empty($year))) {
                     $valid = false;
                 } else {
@@ -209,7 +209,7 @@ class BetterDatetimeField extends FormField
         return $this->showTime;
     }
 
-    public function setShowTimeFields(bool $bool)
+    public function setShowTimeFields($bool)
     {
         $this->showTime = $bool;
         return $this;
@@ -220,7 +220,7 @@ class BetterDatetimeField extends FormField
         return $this->showDate;
     }
 
-    public function setShowDateFields(bool $bool)
+    public function setShowDateFields($bool)
     {
         $this->showDate = $bool;
         return $this;


### PR DESCRIPTION
The composer file implies this is plugin is compatible with older PHP but the use of scalar types in  setShowTimeFields and setShowDateFields only work with PHP 7. I feel removing this makes the plugin more usable.
